### PR TITLE
fix multiclass predictions

### DIFF
--- a/imodelsx/embgam/embgam.py
+++ b/imodelsx/embgam/embgam.py
@@ -266,8 +266,12 @@ class EmbGAM(BaseEstimator):
         assert hasattr(self, 'coefs_dict_'), 'coefs are not cached!'
         preds = []
         n_unseen_ngrams = 0
+        n_classes = len(self.classes_)
         for x in X:
-            pred = 0
+            if n_classes > 2:
+                pred = np.zeros(n_classes)
+            else:
+                pred = 0
             seqs = imodelsx.embgam.embed.generate_ngrams_list(
                 x,
                 ngrams=self.ngrams,


### PR DESCRIPTION
Fixes a bug in the `_predict_cached` function for multiclass classification
- for multiclass, pred becomes an array instead of a scalar. The offending line is `return np.array(preds)` which errors if preds (which is a list) contains arrays and scalars (0 when the seq does not belong in the coefs_dict_)